### PR TITLE
Better third party theme support

### DIFF
--- a/view/base/templates/loader.phtml
+++ b/view/base/templates/loader.phtml
@@ -11,22 +11,19 @@ $viewModel = $block->getData('viewModel');
 ?>
 
 <?php if ($viewModel->isToolbarEnabled()): ?>
-<script>
-    require(
-        ['jquery'],
-        function ($) {
-            $('document').ready(function () {
-                $.ajax({
-                    url: '<?= $escaper->escapeUrl($block->getUrl('smile_debug_toolbar')) ?>',
-                    success: function (html) {
-                        $('body').append(html);
-                    },
-                    error: function (xhr) {
-                        console.log('Failed to load the debug toolbar: ' + xhr.responseText);
-                    }
-                });
+    <script>
+        document.addEventListener('DOMContentLoaded', () => {
+            fetch('<?= $escaper->escapeUrl($block->getUrl('smile_debug_toolbar')) ?>', {
+                method: 'GET',
+            }).then((response) => {
+                return response.text();
+            }).then((html) => {
+                const fragment = document.createRange().createContextualFragment(html);
+
+                document.body.append( fragment);
+            }).catch((error) => {
+                console.log(`Failed to load the debug toolbar: ${error}`);
             });
-        }
-    );
-</script>
+        });
+    </script>
 <?php endif ?>


### PR DESCRIPTION
- Now (in theory) supports any theme out of the box as it is no longer dependant upon any libraries
	- Primary candidate for this change is Hyvä Themes
- Removes jQuery dependency
- Removes RequireJS dependency

I think it's safe to assume we're not developing with IE 11 anymore. Arrow functions, template literals and `fetch` are supported by all modern browsers.